### PR TITLE
feat: add fifth class year option

### DIFF
--- a/src/apis/hooks/yearId/useGetClassYearList.ts
+++ b/src/apis/hooks/yearId/useGetClassYearList.ts
@@ -15,7 +15,22 @@ const teamListQueryKey = [getClassYearListPath()];
 
 const getClassYearList = async () => {
   const response = await fetchInstance.get(getClassYearListPath());
-  return response.data;
+  const data: classYearList[] = response.data;
+
+  // 신규 기수(5기)를 추가해 드롭다운에서 선택할 수 있도록 합니다.
+  const hasFifth = data.some(
+    (year) => year.id === 5 || year.name === '5기'
+  );
+  if (!hasFifth) {
+    data.push({
+      id: 5,
+      name: '5기',
+      applyStartDateTime: '',
+      applyEndDateTime: '',
+    });
+  }
+
+  return data;
 };
 
 export const useGetClassYearList = (): UseQueryResult<


### PR DESCRIPTION
## Summary
- ensure class-year API includes 5th generation as selectable option

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68a42dcefcb8832f9e406590de7aa8d8